### PR TITLE
ruby/IOKit: Add handling of UsagePage field

### DIFF
--- a/ruby/input/joypad/iokit.cpp
+++ b/ruby/input/joypad/iokit.cpp
@@ -14,14 +14,16 @@ struct InputJoypadIOKit {
       for(uint n : range(CFArrayGetCount(elements))) {
         IOHIDElementRef element = (IOHIDElementRef)CFArrayGetValueAtIndex(elements, n);
         IOHIDElementType type = IOHIDElementGetType(element);
+        uint32_t page = IOHIDElementGetUsagePage(element);
         uint32_t usage = IOHIDElementGetUsage(element);
-        print("appendElements ", elements, " ", element, " ", (int) type, " ", hex(usage), "\n");
+        print("appendElements ", elements, " ", element, " ", (int) type, " ", hex(page), " ", hex(usage), "\n");
         switch(type) {
         case kIOHIDElementTypeInput_Button:
           appendButton(element);
           break;
         case kIOHIDElementTypeInput_Axis:
         case kIOHIDElementTypeInput_Misc:
+          if(page != kHIDPage_GenericDesktop && page != kHIDPage_Simulation) break;
           if(usage == kHIDUsage_Sim_Accelerator || usage == kHIDUsage_Sim_Brake
           || usage == kHIDUsage_Sim_Rudder      || usage == kHIDUsage_Sim_Throttle
           || usage == kHIDUsage_GD_X  || usage == kHIDUsage_GD_Y  || usage == kHIDUsage_GD_Z


### PR DESCRIPTION
This fixes an unknown number of Bluetooth and possibly USB devices on macOS Catalina. For example, the Sony PlayStation 4 controller, and its compatible devices, contain hundreds of vendor defined extensions that were being detected as GD_X axes, when they were clearly marked as:
```
    kHIDPage_VendorDefinedStart     = 0xFF00
```
And not kHIDPage_GenericDesktop.

This change polls the UsagePage field, and restricts the axis handling to GenericDesktop or Simulation pages.

Thanks careful Google searching and a handful of useful example source repositories for documenting that this field even exists. No thanks to Apple's documentation page for making this a pain to search out.